### PR TITLE
properly handle script and style tags so they are rendered as they should be

### DIFF
--- a/prepare.js
+++ b/prepare.js
@@ -7,16 +7,16 @@ module.exports = function prepare ($, location) {
                      '<script src=/js/commandline.js></script>'].join('');
 
   // strip particular elements
-  $('style,iframe,frame,frameset,img,hr,br,video').remove();
+  $('iframe,frame,frameset,img,hr,br,video').remove();
+  $('script,style').each(function(){
+    var $this = $(this);
+    var $span = $('<span>');
+    $span.html($this.html());
+    $this.replaceWith($span);
+  });
   $('link[rel=stylesheet]').remove();
   $('[style]').each(function () {
     $(this).removeAttr('style');
-  });
-
-
-  // expose the content of scripts
-  $('script').each(function () {
-    $(this).attr('type', 'text/plain');
   });
 
 

--- a/public/js/linemodethis.js
+++ b/public/js/linemodethis.js
@@ -30,7 +30,10 @@ var linemoder = {
 
 		for (var i=0; i < styleSheets.length; i++) {
 			if ((' ' + styleSheets[i].className + ' ').indexOf(' ignore ') === -1) {
-				styleSheets[i].parentNode.removeChild(styleSheets[i]);
+				var styleSheet = styleSheets[i];
+				var span = document.createElement('span');
+				span.innerHTML = styleSheet.innerHTML;
+				styleSheet.parentNode.replaceChild(span, styleSheet);
 			}
 		};
 
@@ -52,7 +55,10 @@ var linemoder = {
 		for (var i=0; i < scripts.length; i++) {
 			if ((' ' + scripts[i].className + ' ').indexOf(' ignore ') === -1) {
 				//don't remove this script
-				scripts[i].parentNode.removeChild(scripts[i])
+				var script = scripts[i];
+				var span = document.createElement('span');
+				span.innerHTML = script.innerHTML;
+				script.parentNode.replaceChild(span, script);
 			}
 		};
 


### PR DESCRIPTION
My attempt at fixing issue #16, wherein script and style tags are not rendered as they should be.  My [test](http://tobymackenzie.com/examples/html/scriptAndStyle.html) mostly comes out as expected, though a bit of the comments from one of the CDATA style comment wrappers is showing up.  I'm not sure if this is what would happen in actual line mode or not.

The changes to prepare.js are the important ones for the node served lmb.  The changes to linemodethis.js are apparently for a bookmarklet, though I'm not sure how to use it.

This is my first pull request, so let me know if I'm doing something wrong.
